### PR TITLE
Add more key gpg server to avoid network failures

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -21,7 +21,12 @@ RUN apt-get update \
 RUN set -ex; \
   key='A4A9406876FCBD3C456770C88C718D3B5072E1F5'; \
   export GNUPGHOME="$(mktemp -d)"; \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  ( \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+    || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" \
+  ); \
   gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/mysql.gpg; \
   gpgconf --kill all; \
   rm -rf "$GNUPGHOME"; \

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -61,8 +61,8 @@ if [ "$1" = 'mysqld' ]; then
       ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
       GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
 
-      CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-      GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+      CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+      GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;
 
       FLUSH PRIVILEGES;
       DROP DATABASE IF EXISTS test;


### PR DESCRIPTION
Avoid gpg key server connection failures by adding more server in order to give second chance the step to complete.